### PR TITLE
 add support for power law energy distributions

### DIFF
--- a/crprop/particle_utils.py
+++ b/crprop/particle_utils.py
@@ -61,13 +61,18 @@ def sph2cart(r, az, el):
     z = r * numpy.cos(el)
     return x, y, z
 
-def initial_buffers(num_particles, Emin, Emax):
+def initial_buffers(num_particles, Emin, Emax, alpha=None):
     np_position = numpy.ndarray((num_particles, 4), dtype=numpy.float32)
     np_velocity = numpy.ndarray((num_particles, 4), dtype=numpy.float32)
     np_zmel = numpy.ndarray((num_particles, 4), dtype=numpy.float32)
 
     ## Test values
-    Energy_array = numpy.logspace(numpy.log10(Emin),numpy.log10(Emax),num_particles)
+    if alpha:
+        E = 10**numpy.arange(numpy.log10(Emin), numpy.log10(Emax), 0.01)
+        weights = E**-alpha
+        Energy_array = numpy.random.choice(E, size=num_particles, p=weights/weights.sum())
+    else:
+        Energy_array = numpy.logspace(numpy.log10(Emin),numpy.log10(Emax),num_particles)
     Gamma_array = Energy_array/masseV+1.
     np_zmel[:,0] = chargeC
     np_zmel[:,1] = masskg

--- a/crprop/run.py
+++ b/crprop/run.py
@@ -371,6 +371,8 @@ if __name__=="__main__":
     parser.add_argument("-n", "--num_particles", dest="num_particles", default=1000, type=check_positive_int, help="Number of particles to simulate")
     parser.add_argument("-e", "--Emin", dest="Emin", default=1e7, type=check_positive_float, help="Minimum energy of particles (eV)")
     parser.add_argument("-E", "--Emax", dest="Emax", default=1e8, type=check_positive_float, help="Maximum energy of particles (eV)")
+    parser.add_argument("-a", "--alpha", dest="alpha", type=float,
+                        help="Option energy spectral index. If given, weight the energy distribution of events by E^-alpha.")
     args = parser.parse_args()
 
     # Get particle parameters
@@ -388,7 +390,7 @@ if __name__=="__main__":
     texture = load_texture(texture_file)
    
     # Initialize the necessary particle information
-    (np_position, np_velocity, np_zmel) = initial_buffers(num_particles, Emin, Emax)
+    (np_position, np_velocity, np_zmel) = initial_buffers(num_particles, Emin, Emax, alpha=args.alpha)
     
     # Arrays for OpenGL bindings
     gl_position = vbo.VBO(data=np_position, usage=GL_DYNAMIC_DRAW, target=GL_ARRAY_BUFFER)

--- a/crprop/run.py
+++ b/crprop/run.py
@@ -372,7 +372,7 @@ if __name__=="__main__":
     parser.add_argument("-e", "--Emin", dest="Emin", default=1e7, type=check_positive_float, help="Minimum energy of particles (eV)")
     parser.add_argument("-E", "--Emax", dest="Emax", default=1e8, type=check_positive_float, help="Maximum energy of particles (eV)")
     parser.add_argument("-a", "--alpha", dest="alpha", type=float,
-                        help="Option energy spectral index. If given, weight the energy distribution of events by E^-alpha.")
+                        help="Optional energy spectral index. If given, weight the energy distribution of events by E^-alpha.")
     args = parser.parse_args()
 
     # Get particle parameters


### PR DESCRIPTION
This pull request adds the option to weight your particle energy distribution to a specified power law.  If not given, the energy distribution is constructed the same as before.