### PR TITLE
Add yaml config file for run.py arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # Charged Particle in Geomagnetic Field Visualization
 
-This project (cr-geomag-prop) demonstrates a tool to visualize charge particle 
+[![Build Status](https://travis-ci.org/zhampel/cr-geomag-prop.svg?branch=master)](https://travis-ci.org/zhampel/cr-geomag-prop)
+![Python 2.7](https://img.shields.io/badge/python-2.7-blue.svg)
+[![GitHub license](https://img.shields.io/github/license/zhampel/cr-geomag-prop.svg)](https://github.com/zhampel/cr-geomag-prop/blob/master/LICENSE)
+
+This project (cr-geomag-prop) demonstrates a tool to visualize charge particle
 propagation through the Earth's magnetic field using PyOpenCL and PyOpenGL.
 The following [link](https://youtu.be/0FDwW1mo2Vk)
-shows a demonstration of this project's visualization of GeV proton particles 
+shows a demonstration of this project's visualization of GeV proton particles
 interacting with the geomagnetic field, while below is a screenshot from this simulation.
 
 To check-out the repo:
@@ -16,7 +20,7 @@ git clone https://github.com/zhampel/cr-geomag-prop.git
   <img src="docs/images/screenshot.png" width="500" />
 </p>
 
-The Earth texture was obtained freely at the 
+The Earth texture was obtained freely at the
 [Planetary Pixel Emporium](http://planetpixelemporium.com/earth.html).
 
 
@@ -25,7 +29,7 @@ The Earth texture was obtained freely at the
 There are two available models for estimating the geomagnetic field.
 The first is the dipole approximation, where the axis of the field
 is tilted by 11.5 deg from the Earth's axis of rotation.
-The second is the International Geomagnetic Reference Field 
+The second is the International Geomagnetic Reference Field
 ([IGRF](https://www.ngdc.noaa.gov/IAGA/vmod/igrf.html)),
 a best fit model to satellite borne and ground based sensor measurements
 using a 13-order expansion of Legendre functions.
@@ -43,7 +47,7 @@ These diagrams were generated using the following MATLAB
 
 Links showing short video demos of propagating protons in these fields are provided for the
 [IGRF](https://youtu.be/0FDwW1mo2Vk)
-model as well as the 
+model as well as the
 [dipole](https://youtu.be/YA2j0FwJTsI)
 approximation.
 
@@ -55,7 +59,7 @@ python crprop/run.py -p proton -n 1000 -e 1e7 1e8 --lat_lon_alt 18.99 -97.308 3 
 to start the simulation, where `-p` defines the species to run,
 the number of particles to simulate is given by `-n`,
 and the minimum and maximum particle energy in electronvolts (eV) are provided as a list via `-e`.
-The `--lat_lon_alt` flag allows the user to specify the particles's starting latitude and longitude in degrees, 
+The `--lat_lon_alt` flag allows the user to specify the particles's starting latitude and longitude in degrees,
 and the height above the Earth's surface in Earth radii.
 Finally, the `-s` option allows the user to choose the equation of motion integrator.
 The values shown in the line above are the defaults, thus users can do a first run simply
@@ -63,15 +67,15 @@ via `python crprop/run.py`.
 
 ## Visualization
 Once the window opens, one can also use various mouse operations to change the scene.
-Holding the left mouse button allows the user to move the viewing position, while 
+Holding the left mouse button allows the user to move the viewing position, while
 holding down the right mouse button and moving up and down on the screen provides
 a zooming operation.
 The center mouse button provides translation of the origin about the screen.
 
 The colors of the particles are representative of their energy, and are correlated
 per the respective wavelengths.
-Red corresponds to the lowest energies, while violet represents the highest values. 
-The color-to-energy scaling is log-linear, thus color wavelength is proportional 
+Red corresponds to the lowest energies, while violet represents the highest values.
+The color-to-energy scaling is log-linear, thus color wavelength is proportional
 to the logarithm of the particle energy.
 
 There are several available user options when running the simulation:
@@ -82,7 +86,7 @@ There are several available user options when running the simulation:
 - `t` key: toggle between a textured Earth and a simple sphere
 - `q` or `Esc` keys: quit the simulation
 
-A BASH script named `crprop/make_mp4.sh` is provided to generate 
+A BASH script named `crprop/make_mp4.sh` is provided to generate
 an mp4 movie if saved frames are present in the `frames` directory.
 One must have ffmpeg installed on the system to make the movie.
 
@@ -91,7 +95,7 @@ One must have ffmpeg installed on the system to make the movie.
 Personally, I've only successfully run using Python2.7, testing on Python3.0 is forthcoming.
 The installation of PyOpenCL and PyOpenGL potentially can be a bit tricky
 depending on the platform, but may be done via `make install` or `pip install -r requirements.txt`.
-If this doesn't work, the best resource for preparing the PyOpenCL installation can 
+If this doesn't work, the best resource for preparing the PyOpenCL installation can
 be found at Andreas Klockner's [website](https://wiki.tiker.net/PyOpenCL/Installation/).
 I have had success with building PyOpenGL from source, but in principle
 can be done via `pip` as shown [here](http://pyopengl.sourceforge.net/).

--- a/crprop/config.yml
+++ b/crprop/config.yml
@@ -1,0 +1,30 @@
+# The default arguments for the run.py script.
+args:
+    # The particle type.
+    # Options: proton, helium, carbon, oxygen, neon, magnesium, silicon, iron
+    # Default: proton.
+    particle_type: 'proton'
+
+    # The number of particles to simulate.
+    num_particles: 1000
+
+    # The minimum and maximum energy bounds for the simulated particles.
+    energy_lims: [1e7, 1e8]
+
+    # If given, weight the energy distribution of events by E^-alpha.
+    # Set to None to evenly distribute events in log10(E).
+    alpha: None
+
+    # [lat, lon, alt], where:
+    # lat: Geodetic latitude of starting particle position in degrees.
+    # lon: Geodetic longitude of starting particle position in degrees.
+    # alt: Height of starting particle position in Earth radii,
+    #      where 1 is ground level.
+    # Default is the location of the HAWC observatory,
+    # with an altitude of 3 Earth radii.
+    lat_lon_alt: [18.99, -97.308, 3]
+
+    # Stepper function to integrate equations of motion.
+    # Options: euler, rk4, boris, adaboris.
+    # Default: boris.
+    eom_step: 'boris'

--- a/crprop/config.yml
+++ b/crprop/config.yml
@@ -5,15 +5,15 @@ args:
     # Default: proton.
     particle_type: 'proton'
 
-    # The number of particles to simulate.
+    # The number of particles to simulate. Default: 1000.
     num_particles: 1000
 
     # The minimum and maximum energy bounds for the simulated particles.
-    energy_lims: [1e7, 1e8]
+    energy_lims: [10000000, 100000000]
 
     # If given, weight the energy distribution of events by E^-alpha.
-    # Set to None to evenly distribute events in log10(E).
-    alpha: None
+    # Default is None, which will evenly distribute events in log10(E).
+    # alpha: 2.0
 
     # [lat, lon, alt], where:
     # lat: Geodetic latitude of starting particle position in degrees.

--- a/crprop/run.py
+++ b/crprop/run.py
@@ -429,7 +429,6 @@ if __name__=="__main__":
     num_particles = args.num_particles
     Emin = args.energy_lims[0]
     Emax = args.energy_lims[1]
-    print(Emax)
     log_Emax = np.log10(Emax)
     Erange = np.log10(Emax)-np.log10(Emin)
     eom_integrator = eom_dict[args.eom_step.lower()]

--- a/crprop/run.py
+++ b/crprop/run.py
@@ -5,6 +5,7 @@ try:
     import sys
     import numpy as np
     import argparse
+    import yaml
     from particle_utils import *
 
     import pygame
@@ -386,17 +387,41 @@ def printHelp():
 if __name__=="__main__":
 
     global args
-    parser = argparse.ArgumentParser(description="Convolutional NN Training Script")
-    parser.add_argument("-p", "--particle", dest="particle_type", default='proton',
-                        help="Particle species type. Default: proton. Options: proton, helium, carbon, oxygen, neon, magnesium, silicon, iron")
-    parser.add_argument("-n", "--num_particles", dest="num_particles", default=1000, type=check_positive_int, help="Number of particles to simulate")
-    parser.add_argument("-e", "--energy_lims", dest="energy_lims", default=[1e7, 1e8], nargs=2, type=check_positive_float, help="Minimum and maximum energy of particles (eV)")
-    parser.add_argument("-a", "--alpha", dest="alpha", type=check_positive_float,
-                        help="Optional energy spectral index. If given, weight the energy distribution of events by E^-alpha.")
-    parser.add_argument("--lat_lon_alt", dest="lat_lon_alt", default=[18.99, -97.308, 3], nargs=3, type=float, help="Geodetic latitude of starting particle position in degrees, Geodetic longitude of starting particle position in degrees, Height of starting particle position in Earth radii where 1 is ground level")
-    parser.add_argument("-s", "--eom_step", dest="eom_step", default='boris',
-                        help="Stepper function to integrate equations of motion. Options: euler, rk4, boris, adaboris. Default: boris")
-    args = parser.parse_args()
+    p = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+                                description=("Launch a simulation of particles "
+                                             "propagating in the geomagnetic field."))
+    p.add_argument("-p", "--particle", dest="particle_type", default="proton",
+                   help=("Particle species type. Options: proton, helium, "
+                         "carbon, oxygen, neon, magnesium, silicon, iron."))
+    p.add_argument("-n", "--num_particles", dest="num_particles", default=1000,
+                   type=check_positive_int,
+                   help="Number of particles to simulate.")
+    p.add_argument("-e", "--energy_lims", dest="energy_lims", nargs=2,
+                   default=[1e7, 1e8], type=check_positive_float,
+                   help="Minimum and maximum energy of particles (eV). ")
+    p.add_argument("-a", "--alpha", dest="alpha", type=check_positive_float,
+                   help=("Optional energy spectral index. "
+                         "If given, weight the energy distribution of events by E^-alpha."))
+    p.add_argument("--lat_lon_alt", dest="lat_lon_alt",
+                   nargs=3, type=float, default=[18.99, -97.308, 3],
+                   help=("Geodetic latitude of starting particle position in degrees, "
+                         "Geodetic longitude of starting particle position in degrees, "
+                         "Height of starting particle position in Earth radii where 1 is ground level."))
+    p.add_argument("-s", "--eom_step", dest="eom_step", default="boris",
+                   help=("Stepper function to integrate equations of motion. "
+                         "Options: boris, adaboris, euler, rk4."))
+    args = p.parse_args()
+    args_dict = vars(args)
+
+    with open("config.yml", 'r') as ymlfile:
+        cfg = yaml.load(ymlfile)
+
+    for arg in cfg["args"]:
+        if arg not in args_dict:
+            raise ValueError(("'{}' specified in the config file "
+                              "is an invalid argument!".format(arg)))
+        else:
+            args_dict[arg] = cfg["args"][arg]
 
     # Get particle parameters
     global particle_type, num_particles, Emin, Emax, log_Emax, Erange, run_options
@@ -404,6 +429,7 @@ if __name__=="__main__":
     num_particles = args.num_particles
     Emin = args.energy_lims[0]
     Emax = args.energy_lims[1]
+    print(Emax)
     log_Emax = np.log10(Emax)
     Erange = np.log10(Emax)-np.log10(Emin)
     eom_integrator = eom_dict[args.eom_step.lower()]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ PyOpenGL
 Pillow
 pyopencl
 astropy
+pyyaml


### PR DESCRIPTION
This PR addresses issue #3 by adding a yaml config file.  This currently works in tandem with argparse:  if an argument is not defined in the config file, the default behavior defined in the parser is used.